### PR TITLE
Add GitHub wiki template for enterprise knowledge base

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,58 @@
 # Github-Wiki
+
+## Purpose
+
+The purpose of this repository is to provide a GitHub wiki template that can be used as an enterprise knowledge base. This template helps organize information related to various business operations, making it easily accessible to all employees and improving workflows and efficiency.
+
+## Usage
+
+1. **Clone the Repository**: Clone this repository to your local machine using the following command:
+   ```bash
+   git clone https://github.com/ndryer/Github-Wiki.git
+   ```
+
+2. **Navigate to the `docs` Directory**: The `docs` directory contains the sample GitHub wiki template with sections for various business operations.
+
+3. **Explore the Categories and Subcategories**: The knowledge base is organized by categories such as "Development", "Marketing", "Sales", and "HR". Each category contains subcategories for specific topics.
+
+4. **Use the Templates**: The `docs/Templates` directory contains templates for creating guide pages, tutorial pages, and reference pages. Follow the instructions in each template to create consistent and well-structured pages.
+
+5. **Tag and Label Pages**: Use tags and labels to categorize content and make it easier to find related pages. Refer to the `docs/Tag_Index.md` page for a list of tags and instructions for using them.
+
+6. **Contribute to the Knowledge Base**: Follow the instructions in the "Contributing" section below to contribute to the knowledge base.
+
+## Table of Contents
+
+- [Purpose](#purpose)
+- [Usage](#usage)
+- [Table of Contents](#table-of-contents)
+- [Contributing](#contributing)
+
+## Contributing
+
+We welcome contributions to the knowledge base! To contribute, follow these steps:
+
+1. **Fork the Repository**: Fork this repository to your own GitHub account.
+
+2. **Create a New Branch**: Create a new branch for your changes using the following command:
+   ```bash
+   git checkout -b your-branch-name
+   ```
+
+3. **Make Your Changes**: Make your changes to the knowledge base. Use the templates provided in the `docs/Templates` directory to ensure consistency.
+
+4. **Commit Your Changes**: Commit your changes with a descriptive commit message using the following command:
+   ```bash
+   git commit -m "Description of your changes"
+   ```
+
+5. **Push Your Changes**: Push your changes to your forked repository using the following command:
+   ```bash
+   git push origin your-branch-name
+   ```
+
+6. **Create a Pull Request**: Create a pull request to merge your changes into the main repository. Provide a clear and concise description of your changes and why they should be merged.
+
+7. **Review and Feedback**: Your pull request will be reviewed by the repository maintainers. Be prepared to make any necessary revisions based on feedback.
+
+Thank you for contributing to the knowledge base!

--- a/docs/Development/Code_Standards.md
+++ b/docs/Development/Code_Standards.md
@@ -1,0 +1,119 @@
+# Code Standards
+
+## Introduction
+
+Code standards are a set of guidelines and best practices for writing clean, maintainable, and efficient code. Adhering to these standards helps ensure consistency across the codebase, making it easier for team members to collaborate and maintain the code.
+
+## Best Practices
+
+### 1. Use Meaningful Variable and Function Names
+
+- Choose descriptive names that clearly convey the purpose of the variable or function.
+- Avoid using single-letter names, except for loop counters.
+- Use camelCase for variable and function names (e.g., `myVariable`, `calculateTotal`).
+
+### 2. Write Modular and Reusable Code
+
+- Break down large functions into smaller, reusable functions.
+- Follow the Single Responsibility Principle (SRP) - each function should have a single responsibility.
+- Use modules or classes to organize related functions and data.
+
+### 3. Comment Your Code
+
+- Write clear and concise comments to explain the purpose of complex code.
+- Use comments to document the expected input and output of functions.
+- Avoid redundant comments that state the obvious.
+
+### 4. Follow Consistent Formatting
+
+- Use consistent indentation (e.g., 2 or 4 spaces) throughout the codebase.
+- Follow a consistent style for braces, parentheses, and other punctuation.
+- Use a linter to enforce formatting rules and catch common errors.
+
+### 5. Write Unit Tests
+
+- Write unit tests for all functions and modules to ensure they work as expected.
+- Use a testing framework (e.g., Jest, Mocha) to organize and run tests.
+- Aim for high test coverage to catch potential issues early.
+
+### 6. Handle Errors Gracefully
+
+- Use try-catch blocks to handle exceptions and errors.
+- Provide meaningful error messages to help diagnose issues.
+- Avoid using generic error messages like "An error occurred."
+
+### 7. Optimize for Performance
+
+- Write efficient code that minimizes resource usage (e.g., CPU, memory).
+- Use appropriate data structures and algorithms for the task at hand.
+- Profile and optimize performance-critical sections of the code.
+
+## Examples
+
+### Example 1: Meaningful Variable Names
+
+```javascript
+// Bad
+let x = 10;
+let y = 20;
+let z = x + y;
+
+// Good
+let width = 10;
+let height = 20;
+let area = width + height;
+```
+
+### Example 2: Modular Code
+
+```javascript
+// Bad
+function processOrder(order) {
+  // Validate order
+  if (!order.id || !order.items) {
+    throw new Error("Invalid order");
+  }
+
+  // Calculate total
+  let total = 0;
+  for (let item of order.items) {
+    total += item.price * item.quantity;
+  }
+
+  // Process payment
+  if (!processPayment(order.paymentInfo, total)) {
+    throw new Error("Payment failed");
+  }
+
+  // Send confirmation
+  sendConfirmation(order.id);
+}
+
+// Good
+function validateOrder(order) {
+  if (!order.id || !order.items) {
+    throw new Error("Invalid order");
+  }
+}
+
+function calculateTotal(items) {
+  let total = 0;
+  for (let item of items) {
+    total += item.price * item.quantity;
+  }
+  return total;
+}
+
+function processOrder(order) {
+  validateOrder(order);
+  let total = calculateTotal(order.items);
+  if (!processPayment(order.paymentInfo, total)) {
+    throw new Error("Payment failed");
+  }
+  sendConfirmation(order.id);
+}
+```
+
+## Conclusion
+
+Following these code standards and best practices will help ensure that your code is clean, maintainable, and efficient. Consistency in coding style and practices makes it easier for team members to collaborate and maintain the codebase, ultimately leading to better software quality.

--- a/docs/Tag_Index.md
+++ b/docs/Tag_Index.md
@@ -1,0 +1,30 @@
+# Tag Index
+
+## Introduction
+
+This page lists all tags used in the knowledge base and links to the pages associated with each tag. Tags help categorize content and make it easier to find related pages.
+
+## Tags
+
+### Development
+
+- **Code Standards**: [Development/Code_Standards.md](Development/Code_Standards.md)
+
+### Marketing
+
+- **Strategies**: [Marketing/Strategies.md](Marketing/Strategies.md)
+
+### Sales
+
+- **Lead Management**: [Sales/Lead_Management.md](Sales/Lead_Management.md)
+
+### HR
+
+- **Policies**: [HR/Policies.md](HR/Policies.md)
+
+## Instructions for Using Tags and Labels
+
+1. **Tag Pages with Relevant Keywords**: Add tags to each page to make it easier to find related content. Use keywords that accurately describe the content of the page.
+2. **Create a Tag Index Page**: Maintain a page that lists all tags and links to the pages associated with each tag. This helps users navigate through the tags and find related content.
+3. **Use Labels for Different Types of Content**: Label pages based on their content type, such as "Guide", "Reference", "Tutorial", etc. This helps users quickly identify the type of content they are looking for.
+4. **Update Tags and Labels Regularly**: Regularly review and update tags and labels to ensure they accurately reflect the content of the pages. Remove any outdated or irrelevant tags and add new tags as needed.

--- a/docs/Templates/Guide_Template.md
+++ b/docs/Templates/Guide_Template.md
@@ -1,0 +1,59 @@
+# Guide Template
+
+## Introduction
+
+This template is designed to help you create consistent and well-structured guide pages for the knowledge base. Follow the instructions below to use this template effectively.
+
+## Guide Title
+
+Provide a clear and concise title for your guide.
+
+## Table of Contents
+
+Include a table of contents to help readers navigate through the guide.
+
+## Introduction
+
+Provide an overview of the guide's purpose and what readers can expect to learn.
+
+## Section 1: [Section Title]
+
+### Subsection 1.1: [Subsection Title]
+
+- Use bullet points to list key points or steps.
+- Provide clear and concise explanations.
+- Include examples to illustrate your points.
+
+### Subsection 1.2: [Subsection Title]
+
+- Use bullet points to list key points or steps.
+- Provide clear and concise explanations.
+- Include examples to illustrate your points.
+
+## Section 2: [Section Title]
+
+### Subsection 2.1: [Subsection Title]
+
+- Use bullet points to list key points or steps.
+- Provide clear and concise explanations.
+- Include examples to illustrate your points.
+
+### Subsection 2.2: [Subsection Title]
+
+- Use bullet points to list key points or steps.
+- Provide clear and concise explanations.
+- Include examples to illustrate your points.
+
+## Conclusion
+
+Summarize the key points covered in the guide and provide any additional resources or references.
+
+## Instructions for Using the Guide Template
+
+1. **Copy the Template**: Copy the content of this template to a new page.
+2. **Fill in the Sections**: Replace the placeholder text with your own content, following the structure provided.
+3. **Use Clear and Concise Language**: Write in a way that is easy to understand for all readers.
+4. **Include Examples**: Provide examples to illustrate your points and make the information more relatable.
+5. **Use Consistent Formatting**: Maintain a consistent style and formatting throughout your guide.
+6. **Update Regularly**: Keep your guide up to date with the latest information and changes.
+7. **Review and Edit**: Proofread your guide for errors and have others review it to ensure clarity and accuracy.

--- a/docs/Templates/Reference_Template.md
+++ b/docs/Templates/Reference_Template.md
@@ -1,0 +1,59 @@
+# Reference Template
+
+## Introduction
+
+This template is designed to help you create consistent and well-structured reference pages for the knowledge base. Follow the instructions below to use this template effectively.
+
+## Reference Title
+
+Provide a clear and concise title for your reference page.
+
+## Table of Contents
+
+Include a table of contents to help readers navigate through the reference page.
+
+## Introduction
+
+Provide an overview of the reference page's purpose and what readers can expect to learn.
+
+## Section 1: [Section Title]
+
+### Subsection 1.1: [Subsection Title]
+
+- Use bullet points to list key points or steps.
+- Provide clear and concise explanations.
+- Include examples to illustrate your points.
+
+### Subsection 1.2: [Subsection Title]
+
+- Use bullet points to list key points or steps.
+- Provide clear and concise explanations.
+- Include examples to illustrate your points.
+
+## Section 2: [Section Title]
+
+### Subsection 2.1: [Subsection Title]
+
+- Use bullet points to list key points or steps.
+- Provide clear and concise explanations.
+- Include examples to illustrate your points.
+
+### Subsection 2.2: [Subsection Title]
+
+- Use bullet points to list key points or steps.
+- Provide clear and concise explanations.
+- Include examples to illustrate your points.
+
+## Conclusion
+
+Summarize the key points covered in the reference page and provide any additional resources or references.
+
+## Instructions for Using the Reference Template
+
+1. **Copy the Template**: Copy the content of this template to a new page.
+2. **Fill in the Sections**: Replace the placeholder text with your own content, following the structure provided.
+3. **Use Clear and Concise Language**: Write in a way that is easy to understand for all readers.
+4. **Include Examples**: Provide examples to illustrate your points and make the information more relatable.
+5. **Use Consistent Formatting**: Maintain a consistent style and formatting throughout your reference page.
+6. **Update Regularly**: Keep your reference page up to date with the latest information and changes.
+7. **Review and Edit**: Proofread your reference page for errors and have others review it to ensure clarity and accuracy.

--- a/docs/Templates/Tutorial_Template.md
+++ b/docs/Templates/Tutorial_Template.md
@@ -1,0 +1,53 @@
+# Tutorial Template
+
+## Introduction
+
+This template is designed to help you create consistent and well-structured tutorial pages for the knowledge base. Follow the instructions below to use this template effectively.
+
+## Tutorial Title
+
+Provide a clear and concise title for your tutorial.
+
+## Table of Contents
+
+Include a table of contents to help readers navigate through the tutorial.
+
+## Introduction
+
+Provide an overview of the tutorial's purpose and what readers can expect to learn.
+
+## Prerequisites
+
+List any prerequisites or requirements needed to complete the tutorial.
+
+## Step 1: [Step Title]
+
+- Use bullet points to list key points or steps.
+- Provide clear and concise explanations.
+- Include examples to illustrate your points.
+
+## Step 2: [Step Title]
+
+- Use bullet points to list key points or steps.
+- Provide clear and concise explanations.
+- Include examples to illustrate your points.
+
+## Step 3: [Step Title]
+
+- Use bullet points to list key points or steps.
+- Provide clear and concise explanations.
+- Include examples to illustrate your points.
+
+## Conclusion
+
+Summarize the key points covered in the tutorial and provide any additional resources or references.
+
+## Instructions for Using the Tutorial Template
+
+1. **Copy the Template**: Copy the content of this template to a new page.
+2. **Fill in the Sections**: Replace the placeholder text with your own content, following the structure provided.
+3. **Use Clear and Concise Language**: Write in a way that is easy to understand for all readers.
+4. **Include Examples**: Provide examples to illustrate your points and make the information more relatable.
+5. **Use Consistent Formatting**: Maintain a consistent style and formatting throughout your tutorial.
+6. **Update Regularly**: Keep your tutorial up to date with the latest information and changes.
+7. **Review and Edit**: Proofread your tutorial for errors and have others review it to ensure clarity and accuracy.


### PR DESCRIPTION
Add a GitHub wiki template for the enterprise's knowledge base.

* **README.md**
  - Add a description of the purpose and usage of the knowledge base template.
  - Add a table of contents for the repository.
  - Add instructions for contributing to the knowledge base.

* **docs/Development/Code_Standards.md**
  - Add a page for Code Standards in the Development category.
  - Include a description of code standards and best practices.
  - Use headings, bullet points, and examples for clarity.

* **docs/Tag_Index.md**
  - Add a page listing all tags and linking to associated pages.
  - Include instructions for using tags and labels.

* **docs/Templates/Guide_Template.md**
  - Add a template for creating guide pages.
  - Include instructions for using the guide template.

* **docs/Templates/Tutorial_Template.md**
  - Add a template for creating tutorial pages.
  - Include instructions for using the tutorial template.

* **docs/Templates/Reference_Template.md**
  - Add a template for creating reference pages.
  - Include instructions for using the reference template.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ndryer/Github-Wiki/pull/1?shareId=0cdf76b0-2fb0-4ff2-a451-e1faa21fa711).